### PR TITLE
Fixed off-by-one shift when rendering empty line on the Y-axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Changed
-- 
+- Fixed off-by-one shift when rendering empty lines on the Y-axis (the issue was visible only when the Y-axis was on the left side)
 
 ### Removed
 - 

--- a/src/candlestick_chart/y_axis.py
+++ b/src/candlestick_chart/y_axis.py
@@ -100,7 +100,7 @@ class YAxis:
             return " │"
 
         cell = " " * (constants.CHAR_PRECISION + constants.DEC_PRECISION + 2)
-        margin = " " * (constants.MARGIN_RIGHT + 1)
+        margin = " " * constants.MARGIN_RIGHT
         return f"{cell}│{margin}"
 
     def _render_tick(


### PR DESCRIPTION
(the issue was visible only when the Y-axis was on the left side)

Screenshot of the issue, with specific colors to highlight the issue:
![before](https://user-images.githubusercontent.com/2033598/232127716-c509a7d1-f348-4a1b-a5b6-f4b5d776d25a.jpg)

With the fix:
![after](https://user-images.githubusercontent.com/2033598/232127753-f90a256b-bcdf-47db-836f-39c3b7fda2ad.jpg)
