### PR TITLE
Set the default chart name to a blank string in the CLI (fixes #9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    assignees:
+      - BoboTiG
+
+  # Python requirements
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    assignees:
+      - BoboTiG

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,5 @@ jobs:
           check-latest: true
           python-version: ${{ matrix.python.runs-on }}
       - run: python -m pip install -U pip wheel
-      - run: python -m pip install -r dev-requirements.txt
+      - run: python -m pip install -r requirements-dev.txt
       - run: python -m pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           cache: pip
+          cache-dependency-path: requirements-dev.txt
           check-latest: true
           python-version: ${{ matrix.python.runs-on }}
       - run: python -m pip install -U pip wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: "${{ matrix.os.emoji }} ${{ matrix.python.name }}"
+    runs-on: ${{ matrix.os.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - emoji: 🐧
+            runs-on: [ubuntu-latest]
+          - emoji: 🍎
+            runs-on: [macos-latest]
+          - emoji: 🪟
+            runs-on: [windows-latest]
+        python:
+          - name: CPython 3.12
+            runs-on: "3.12-dev"
+          - name: CPython 3.11
+            runs-on: "3.11"
+          - name: CPython 3.10
+            runs-on: "3.10"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          cache: pip
+          check-latest: true
+          python-version: ${{ matrix.python.runs-on }}
+      - run: python -m pip install -U pip wheel
+      - run: python -m pip install -r dev-requirements.txt
+      - run: python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 202x-xx-xx
 
 ### Added
-- 
+- Support for Python 3.12
+- CI to run unit tests
+- Tests for the CLI entry point
 
 ### Changed
-- 
+- Set the default chart name to a blank string in the CLI (fixes [#9])
+- Use `shutil.get_terminal_size()` instead of `os.get_terminal_size()` to be able to run tests without hitting `OSError: [Errno 25] Inappropriate ioctl for device`
+- Fix Mypy error `PEP 484 prohibits implicit Optional`
 
 ### Removed
 - 
@@ -113,3 +117,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/BoboTiG/py-candlestick-chart/issues/3
 [#4]: https://github.com/BoboTiG/py-candlestick-chart/issues/4
 [#5]: https://github.com/BoboTiG/py-candlestick-chart/issues/5
+[#9]: https://github.com/BoboTiG/py-candlestick-chart/issues/9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ flake8
 isort
 mypy
 pytest
+pytest-cov
 requests
 rich
 types-requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,3 +69,13 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 120
+
+[tool:pytest]
+pythonpath = src
+addopts =
+    --showlocals
+    --strict-markers
+    -r fE
+    -v
+    --cov=candlestick_chart
+    --cov-report=term-missing

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Multimedia :: Graphics :: Viewers
     Topic :: Office/Business :: Financial
     Topic :: Scientific/Engineering :: Visualization

--- a/src/candlestick_chart/__main__.py
+++ b/src/candlestick_chart/__main__.py
@@ -60,5 +60,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: nocover
     sys.exit(main())

--- a/src/candlestick_chart/__main__.py
+++ b/src/candlestick_chart/__main__.py
@@ -30,7 +30,7 @@ def get_args() -> Namespace:
         required=True,
     )
     parser.add_argument("-f", "--file", help="[MODE:*-file] File to read candles from.")
-    parser.add_argument("--chart-name", help="Sets the chart name.")
+    parser.add_argument("--chart-name", default="", help="Sets the chart name.")
     parser.add_argument("--bear-color", help="Sets the descending candles color in hexadecimal.")
     parser.add_argument("--bull-color", help="Sets the ascending candles color in hexadecimal.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")

--- a/src/candlestick_chart/chart_data.py
+++ b/src/candlestick_chart/chart_data.py
@@ -1,4 +1,4 @@
-from os import get_terminal_size
+from shutil import get_terminal_size
 
 from . import constants
 from .candle import Candles

--- a/src/candlestick_chart/y_axis.py
+++ b/src/candlestick_chart/y_axis.py
@@ -33,7 +33,7 @@ class YAxis:
             (min_open - min_value) / diff * height,  # min_y
         )
 
-    def render_line(self, y: int, highlights: Dict[str, str | Tuple[int, int, int]] = None) -> str:
+    def render_line(self, y: int, highlights: Dict[str, str | Tuple[int, int, int]] | None = None) -> str:
         return (
             self.render_empty(y=y, highlights=highlights)
             if y % constants.Y_AXIS_SPACING
@@ -83,7 +83,9 @@ class YAxis:
 
         return has_special_price, price
 
-    def render_empty(self, y: float = None, highlights: Dict[str, str | Tuple[int, int, int]] = None) -> str:
+    def render_empty(
+        self, y: float | None = None, highlights: Dict[str, str | Tuple[int, int, int]] | None = None
+    ) -> str:
         if highlights and y:
             has_special_price, price = self._render_price(y, highlights)
             if has_special_price:

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1,0 +1,55 @@
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from candlestick_chart.__main__ import main
+
+EXAMPLES = Path(__file__).parent.parent.parent / "examples"
+OPTIONAL_ARGS = [
+    "",
+    "--chart-name=My BTC Chart",
+    "--bear-color=#b967ff",
+    "--bull-color=ff6b99",
+]
+
+
+def run(args: list[str]) -> None:
+    with patch.object(sys, "argv", new=["candlestick-chart", *filter(lambda a: a, args)]):
+        assert main() == 0
+
+
+@pytest.mark.parametrize("additionnal_arg", OPTIONAL_ARGS)
+def test_mode_stdin(additionnal_arg: str):
+    data = StringIO(
+        """[
+  {
+    "open": 28994.009766,
+    "high": 29600.626953,
+    "low": 28803.585938,
+    "close": 29374.152344
+  },
+  {
+    "open": 29376.455078,
+    "high": 33155.117188,
+    "low": 29091.181641,
+    "close": 32127.267578
+  }
+]"""
+    )
+    with patch.object(sys, "stdin", data):
+        run(["--mode=stdin", additionnal_arg])
+
+
+@pytest.mark.parametrize("additionnal_arg", OPTIONAL_ARGS)
+def test_mode_csv_file(additionnal_arg: str):
+    file = EXAMPLES / "BTC-USD.csv"
+    run(["--mode=csv-file", f"--file={file}", additionnal_arg])
+
+
+@pytest.mark.parametrize("additionnal_arg", OPTIONAL_ARGS)
+def test_mode_json_file(additionnal_arg: str):
+    file = EXAMPLES / "BTC-chart.json"
+    run(["--mode=json-file", f"--file={file}", additionnal_arg])


### PR DESCRIPTION
Fixes #9.

Also:
- Fix Mypy error `PEP 484 prohibits implicit Optional`
- Use `shutil.get_terminal_size()` instead of `os.get_terminal_size()` to be able to run tests without hitting `OSError: [Errno 25] Inappropriate ioctl for device`
- Support for Python 3.12
- CI to run unit tests
- Tests for the CLI entry point